### PR TITLE
Change permissions before initializing database

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -6,8 +6,8 @@ DIR="/var/lib/postgresql/10/main"
 if [ "$(ls -A $DIR)" ]; then
     echo "database exists"
 else
-    sudo -u postgres /usr/lib/postgresql/10/bin/initdb -D $DIR
     chown -R postgres:postgres $DIR
+    sudo -u postgres /usr/lib/postgresql/10/bin/initdb -D $DIR
 fi
 
 sed -i 's/peer/trust/g' /etc/postgresql/10/main/pg_hba.conf


### PR DESCRIPTION
When attempting to run this container for the first time with a custom database volume, the container exits with the following logs because `docker-entrypoint.sh` attempts to initialize the database without first changing the permissions of the data directory.

```
The files belonging to this database system will be owned by user "postgres".
This user must also own the server process.

The database cluster will be initialized with locale "C".
The default database encoding has accordingly been set to "SQL_ASCII".
The default text search configuration will be set to "english".

Data page checksums are disabled.

initdb: could not change permissions of directory "/var/lib/postgresql/10/main": Operation not permitted
fixing permissions on existing directory /var/lib/postgresql/10/main ...
```