### PR TITLE
Add the PUID and PGID in the config

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,6 +4,11 @@ services:
   unifi-protect:
     image: markdegroot/unifi-protect-x86
     container_name: unifi-protect
+    environment:
+      - PUID=999
+      - PGID=999
+      - MEM_LIMIT=1024M
+      - MEM_STARTUP=1024M
     volumes:
       - unifi-protect-db:/var/lib/postgresql/10/main
       - unifi-protect:/srv/unifi-protect


### PR DESCRIPTION
In relation with #8 

You should set the puid and pgid as unifi-protect user is define as 999 in the passwd.
      - PUID=999
      - PGID=999
And add a memory limit by default.
      - MEM_LIMIT=1024M
      - MEM_STARTUP=1024M